### PR TITLE
Fixed build issue

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,9 +6,9 @@ using namespace ACA;
 
 int main()
 {
-	BigInt num1("22507");
-    BigInt num2("234512003");
-    BigInt num3=("0");
+	BigInt num1(std::string("22507"));
+    BigInt num2(std::string("234512003"));
+    BigInt num3 = std::string("0");
     BigInt num4 = std::string("1") + num3;
 
     std::cout<<(num1>num2)<<std::endl;


### PR DESCRIPTION
Fixed the build issue.

BigInt class has 3 constructors
```
BigInt(unsigned long long n = 0);
BigInt(const std::string&);
BigInt(const BigInt&); // Copy constructor
```
We have constructors accepting `unsigned long long` and `const std::string&`. 
```
BigInt first(1); // will call BigInt(unsigned long long n = 0);
BigInt second(std::string("2")); // will call BigInt(const std::string&);
```

What happens when we call `BigInt first("1");`?
type of "1" is `const char *`

Error message that we get is:
```
Error: /home/runner/work/BigInt/BigInt/src/main.cpp:11:[18](https://github.com/LauraHovhannisyan/BigInt/actions/runs/4158038444/jobs/7192972951#step:5:19): error: invalid conversion from ‘const char*’ to ‘long long unsigned int’ [-fpermissive]
   11 |     BigInt num3=("0");
      |                 ~^~~~
      |                  |
      |                  const char*
In file included from /home/runner/work/BigInt/BigInt/src/main.cpp:1:
/home/runner/work/BigInt/BigInt/src/BigInt/include/BigInt/BigInt.h:13:35: note:   initializing argument 1 of ‘ACA::BigInt::BigInt(long long unsigned int)’
   13 |         BigInt(unsigned long long n = 0);
      |                ~~~~~~~~~~~~~~~~~~~^~~~~
```

![build-failure-compiler](https://user-images.githubusercontent.com/4984553/218427413-9bef35ef-baf1-4930-9474-be45047f2e2c.jpg)

As we can see here the error message is pointing out that it tries to call `ACA::BigInt::BigInt(long long unsigned int)` constructor. Since the type of `"0"` in `BigInt num3=("0");` is `const char*` and we don't have a constructor waiting `const char*` compiler needs to cast the type either to std::string or unsigned long long. 
